### PR TITLE
fix: move 'babel-plugin-transform-object-rest-spread' to 'dependencies'

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "bcrypt": "^1.0.3",
     "body-parser": "^1.18.2",
@@ -62,7 +63,6 @@
     "webpack": "^3.10.0"
   },
   "devDependencies": {
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "codecov": "^3.0.0",
     "coveralls": "^3.0.0",
     "eslint": "^4.9.0",


### PR DESCRIPTION
#### What does this PR do?

This is an attempt to solve the Heroku issue: `ReferenceError: Unknown plugin "transform-object-rest-spread"`

#### Description of Task to be completed?

Heroku seems not to be able to find babel plugin `"transform-object-rest-spread"`. From what I have read, it has something to do with the (in)famous caching behaviour of Heroku, as well as `babel-plugin-transform-object-rest-spread` being listed under `devDpendencies` instead of `dependencies`.

To try and resolve this, I have set the Heroku environment variable `NODE_MODULES_CACHE` to false, and moved `babel-plugin-transform-object-rest-spread` to `dependencies`.

This worked in `staging`. Let's hope it works here.
