### PR TITLE
#157691889 private teams should be accessible only to members

### DIFF
--- a/src/controllers/Teams.js
+++ b/src/controllers/Teams.js
@@ -171,6 +171,11 @@ export default class Teams {
       const team =
       await helpers.Misc.updateTeamAttributes(req.existingTeam, req);
 
+      // you can't view a private team that doesn't contain you
+      if (team.private && !team.containsYou) {
+        throw new Error('This team is private.');
+      }
+
       return res.sendSuccess({ team });
     } catch (error) {
       return res.sendFailure([error.message]);

--- a/src/server.js
+++ b/src/server.js
@@ -53,7 +53,9 @@ const app = express();
 app.set('port', port);
 
 // Log requests to the console.
-app.use(logger('dev'));
+if (env !== 'test') {
+  app.use(logger('dev'));
+}
 
 // CORS
 /*

--- a/test/controllers/members.spec.js
+++ b/test/controllers/members.spec.js
@@ -68,7 +68,6 @@ describe('MembersController', () => {
 
           chai.request(server)
             .get(`/v1/teams/${team1.id}/members/${user0.id}`)
-            .send({})
             .set('x-teams-user-token', mock.user0.token)
             .end((err2, res2) => {
               res2.should.have.status(200);
@@ -106,7 +105,6 @@ describe('MembersController', () => {
 
           chai.request(server)
             .get(`/v1/teams/${team1.id}/members/${user1.id}`)
-            .send({})
             .set('x-teams-user-token', mock.user0.token)
             .end((err2, res2) => {
               res2.should.have.status(200);
@@ -145,7 +143,6 @@ describe('MembersController', () => {
 
           chai.request(server)
             .get(`/v1/teams/${team1.id}/members/${user0.id}`)
-            .send({})
             .set('x-teams-user-token', mock.user0.token)
             .end((err2, res2) => {
               res2.should.have.status(200);


### PR DESCRIPTION
#### What does this PR do?

* Adds checks to ensure only members of a private team can access that team.
* Adds tests for the implementation

#### What are the relevant pivotal tracker stories?

[#157691889 Private teams should be accessible only to team members](https://www.pivotaltracker.com/story/show/157691889)
