### PR TITLE
rename 'Validation' middleware to 'Validate'

### DIFF
--- a/src/middleware/Validate.js
+++ b/src/middleware/Validate.js
@@ -1,5 +1,5 @@
 /**
- * @fileOverview Validation middleware
+ * @fileOverview Validate middleware
  *
  * @author Franklin Chieze
  *
@@ -35,9 +35,9 @@ const createTeamMemberRules = {
 
 /**
 * Middleware for validations
-* @class Validation
+* @class Validate
 */
-export default class Validation {
+export default class Validate {
   /**
   * Validate sign in user data
   * @param {object} req express request object
@@ -46,7 +46,7 @@ export default class Validation {
   *
   * @returns {any} the next middleware or controller
   */
-  async validateSigninUser(req, res, next) {
+  async signinUser(req, res, next) {
     const validation = new Validator(req.body, signinUserRules);
     validation.fails(() => res.sendFailure([
       ...validation.errors.get('displayName'),
@@ -65,7 +65,7 @@ export default class Validation {
   *
   * @returns {any} the next middleware or controller
   */
-  async validateSignupUser(req, res, next) {
+  async signupUser(req, res, next) {
     const validation = new Validator(req.body, signupUserRules);
     validation.fails(() => res.sendFailure([
       ...validation.errors.get('displayName'),
@@ -86,7 +86,7 @@ export default class Validation {
   *
   * @returns {any} the next middleware or controller
   */
-  async validateCreateTeam(req, res, next) {
+  async createTeam(req, res, next) {
     const validation = new Validator(req.body, createTeamRules);
     validation.fails(() => res.sendFailure([
       ...validation.errors.get('name'),
@@ -106,7 +106,7 @@ export default class Validation {
   *
   * @returns {any} the next middleware or controller
   */
-  async validateCreateTeamMember(req, res, next) {
+  async createTeamMember(req, res, next) {
     const validation = new Validator(req.body, createTeamMemberRules);
     validation.fails(() => res.sendFailure([
       ...validation.errors.get('role'),

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -17,11 +17,11 @@ import filter from './filter';
 import pagination from './pagination';
 import search from './search';
 import sort from './sort';
-import Validation from './Validation';
+import Validate from './Validate';
 
 const auth = new Auth();
 const confirmation = new Confirmation();
-const validation = new Validation();
+const validate = new Validate();
 
 export default {
   api,
@@ -31,5 +31,5 @@ export default {
   pagination,
   search,
   sort,
-  validation
+  validate
 };

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -33,7 +33,7 @@ const routes = new Router();
    */
 routes.post(
   '/signin',
-  middleware.validation.validateSigninUser,
+  middleware.validate.signinUser,
   authController.signin
 );
 /**
@@ -53,7 +53,7 @@ routes.post(
    */
 routes.post(
   '/signup',
-  middleware.validation.validateSignupUser,
+  middleware.validate.signupUser,
   authController.signup
 );
 

--- a/src/routes/members.js
+++ b/src/routes/members.js
@@ -86,7 +86,7 @@ routes.post(
   middleware.confirmation.confirmTeamById,
   middleware.confirmation.confirmUserById,
   middleware.confirmation.confirmUserIsLeadInTeamById,
-  middleware.validation.validateCreateTeamMember,
+  middleware.validate.createTeamMember,
   membersController.create
 );
 /** routes.put('/:teamId/members/:memberId', teamsController.updateById);

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -79,7 +79,7 @@ routes.get(
 routes.post(
   '/',
   middleware.confirmation.confirmCurrentUserIsAdmin,
-  middleware.validation.validateCreateTeam,
+  middleware.validate.createTeam,
   teamsController.create
 );
 routes.put('/:teamId', teamsController.updateById);


### PR DESCRIPTION
#### What does this PR do?

* Rename `Validation` middleware to `Validate`
* Remove the string `validate` from the beginning of the names of the functions in the `Validate` middleware
