### PR TITLE
Fix: rename 'Confirmation' middleware to 'Check'

### DIFF
--- a/src/middleware/Check.js
+++ b/src/middleware/Check.js
@@ -1,5 +1,5 @@
 /**
- * @fileOverview Confirmation middleware
+ * @fileOverview Check middleware
  *
  * @author Franklin Chieze
  *
@@ -9,10 +9,10 @@
 import models from '../models';
 
 /**
-* Middleware for confirmations
-* @class Confirmation
+* Middleware for checks
+* @class Check
 */
-export default class Confirmation {
+export default class Check {
   /**
   * Confirm that the currently authenticated user is an admin
   * @param {object} req express request object
@@ -21,7 +21,7 @@ export default class Confirmation {
   *
   * @returns {any} the next middleware or controller
   */
-  async confirmCurrentUserIsAdmin(req, res, next) {
+  async currentUserIsAdmin(req, res, next) {
     try {
       if (req.user.role !== 'admin') {
         throw new Error('This user is not an admin.');
@@ -41,7 +41,7 @@ export default class Confirmation {
   *
   * @returns {any} the next middleware or controller
   */
-  async confirmTeamById(req, res, next) {
+  async teamWithParamsIdExists(req, res, next) {
     try {
       const existingTeam = await models.Team.findOne({
         where: { id: req.params.teamId }
@@ -66,7 +66,7 @@ export default class Confirmation {
   *
   * @returns {any} the next middleware or controller
   */
-  async confirmUserById(req, res, next) {
+  async userWithParamsIdExists(req, res, next) {
     try {
       const existingUser = await models.User.findOne({
         where: { id: req.params.userId }
@@ -92,7 +92,7 @@ export default class Confirmation {
   *
   * @returns {any} the next middleware or controller
   */
-  async confirmUserIsLeadInTeamById(req, res, next) {
+  async currentUserIsLeadInTeamWithParamsId(req, res, next) {
     try {
       const existingLead = await models.Membership.findOne({
         where: {

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -12,7 +12,7 @@
 
 import api from './api';
 import Auth from './Auth';
-import Confirmation from './Confirmation';
+import Check from './Check';
 import filter from './filter';
 import pagination from './pagination';
 import search from './search';
@@ -20,13 +20,13 @@ import sort from './sort';
 import Validate from './Validate';
 
 const auth = new Auth();
-const confirmation = new Confirmation();
+const check = new Check();
 const validate = new Validate();
 
 export default {
   api,
   auth,
-  confirmation,
+  check,
   filter,
   pagination,
   search,

--- a/src/routes/members.js
+++ b/src/routes/members.js
@@ -35,7 +35,7 @@ routes.use(middleware.auth.authenticateUser);
  */
 routes.get(
   '/:teamId/members',
-  middleware.confirmation.confirmTeamById,
+  middleware.check.teamWithParamsIdExists,
   middleware.pagination,
   middleware.search,
   middleware.sort,
@@ -62,8 +62,8 @@ routes.get(
    */
 routes.get(
   '/:teamId/members/:userId',
-  middleware.confirmation.confirmTeamById,
-  middleware.confirmation.confirmUserById,
+  middleware.check.teamWithParamsIdExists,
+  middleware.check.userWithParamsIdExists,
   membersController.getById
 );
 /**
@@ -83,9 +83,9 @@ routes.get(
    */
 routes.post(
   '/:teamId/members/:userId',
-  middleware.confirmation.confirmTeamById,
-  middleware.confirmation.confirmUserById,
-  middleware.confirmation.confirmUserIsLeadInTeamById,
+  middleware.check.teamWithParamsIdExists,
+  middleware.check.userWithParamsIdExists,
+  middleware.check.currentUserIsLeadInTeamWithParamsId,
   middleware.validate.createTeamMember,
   membersController.create
 );

--- a/src/routes/teams.js
+++ b/src/routes/teams.js
@@ -58,7 +58,7 @@ routes.get(
    */
 routes.get(
   '/:teamId',
-  middleware.confirmation.confirmTeamById,
+  middleware.check.teamWithParamsIdExists,
   teamsController.getById
 );
 /**
@@ -78,7 +78,7 @@ routes.get(
    */
 routes.post(
   '/',
-  middleware.confirmation.confirmCurrentUserIsAdmin,
+  middleware.check.currentUserIsAdmin,
   middleware.validate.createTeam,
   teamsController.create
 );


### PR DESCRIPTION
#### What does this PR do?

* rename 'Confirmation' middleware to 'Check'
* remove 'confirm' from the beginning of the names of the functions in the Check middleware